### PR TITLE
Workaround issue with Cannot read property data of undefined

### DIFF
--- a/src/charts/charts.ts
+++ b/src/charts/charts.ts
@@ -128,6 +128,9 @@ export class BaseChartDirective implements OnDestroy, OnChanges, OnInit {
   }
 
   private updateChartData(newDataValues: number[] | any[]): void {
+    if (!this.chart){
+        this.refresh();
+    }
     if (Array.isArray(newDataValues[0].data)) {
       this.chart.data.datasets.forEach((dataset: any, i: number) => {
         dataset.data = newDataValues[i].data;


### PR DESCRIPTION
Fixes issue with:

```
error_handler.js:60 TypeError: Cannot read property 'data' of undefined
    at BaseChartDirective.updateChartData (charts.js:85)
    at BaseChartDirective.ngOnChanges (charts.js:29)
```

This seems to show up when I manually call ngOnInit() (which I have to do in order to force it to take into account a change in the number of graphed series) _and_ when I hide the graph behind an initially hidden *ngIf.

Similar issues:
https://github.com/valor-software/ng2-charts/issues/630
https://github.com/valor-software/ng2-charts/issues/424

I'm sharing this as a change for others who might encounter and struggle with this issue. I haven't tested or verified this patch for actually merging into master.